### PR TITLE
Fix unused functions in tutorial script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Now also available on [**Add-ons for Firefox**](https://addons.mozilla.org/en-US
 
 Youtube Custom Speed lets you play any Youtube video at any speed you like, from 0.0125x to 16x!
 
-Use the options menu to set your preferred playback rate values. Then, change the speed using buttons at the bottom of the video. It also cooperates with the default Youtube keyboard shortcuts - Shift + , and Shift + .
+Use the options menu to set your preferred playback rate values. Then, change the speed using buttons at the bottom of the video. It also cooperates with the default Youtube keyboard shortcuts - Shift + , and Shift + . You can now assign your own keyboard shortcut to each speed in the list from the options page.

--- a/src/action/components/settings/SpeedList.tsx
+++ b/src/action/components/settings/SpeedList.tsx
@@ -1,4 +1,5 @@
 import { useStorage } from "@/hooks/useStorage";
+import { formatShortcut } from "@/utils/keyboardShortcut";
 import {
   Box,
   Button,
@@ -13,6 +14,10 @@ import { ChangeEvent, FormEvent, useState } from "react";
 
 function SpeedList() {
   const [speedList, setSpeedList] = useStorage("speedList", [] as number[]);
+  const [speedShortcuts, setSpeedShortcuts] = useStorage(
+    "speedShortcuts",
+    {} as Record<string, string>,
+  );
   const [newValue, setNewValue] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
 
@@ -38,13 +43,18 @@ function SpeedList() {
     }
 
     setSpeedList((current) =>
-      [...current, valueParsed].toSorted((a, b) => a - b)
+      [...current, valueParsed].toSorted((a, b) => a - b),
     );
     setNewValue("");
   };
 
   const handleDelete = (value: number) => {
     setSpeedList((current) => current.filter((speed) => speed !== value));
+    setSpeedShortcuts((current) => {
+      const newMap = { ...current };
+      delete newMap[value];
+      return newMap;
+    });
   };
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -72,13 +82,42 @@ function SpeedList() {
         }}
       >
         {speedList.map((speed) => (
-          <Chip
+          <Box
             key={speed}
-            size="lg"
-            endDecorator={<ChipDelete onDelete={() => handleDelete(speed)} />}
+            sx={{ display: "flex", alignItems: "center", gap: 1 }}
           >
-            {`${speed}x`}
-          </Chip>
+            <Chip
+              size="lg"
+              endDecorator={<ChipDelete onDelete={() => handleDelete(speed)} />}
+            >
+              {`${speed}x`}
+            </Chip>
+            <Input
+              readOnly
+              placeholder="Shortcut"
+              value={speedShortcuts[speed] ?? ""}
+              onKeyDown={(e) => {
+                e.preventDefault();
+                const value = formatShortcut(e);
+                setSpeedShortcuts((curr) => ({ ...curr, [speed]: value }));
+              }}
+              sx={{ width: 160 }}
+            />
+            {speedShortcuts[speed] && (
+              <Button
+                size="sm"
+                onClick={() =>
+                  setSpeedShortcuts((curr) => {
+                    const map = { ...curr };
+                    delete map[speed];
+                    return map;
+                  })
+                }
+              >
+                Clear
+              </Button>
+            )}
+          </Box>
         ))}
       </Box>
       <Box sx={{ alignSelf: "flex-start" }}>

--- a/src/background/install.ts
+++ b/src/background/install.ts
@@ -9,6 +9,7 @@ async function initializeStorage() {
     storageSchemaVersion: 2,
     lastSpeed: 1,
     speedList: [0.1, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 3, 5, 16],
+    speedShortcuts: {},
     newTabSpeed: {
       selectedOption: "normal",
       isCustomSelected: false,

--- a/src/background/update.ts
+++ b/src/background/update.ts
@@ -40,6 +40,7 @@ async function migrateFromV1() {
     storageSchemaVersion: 2,
     lastSpeed: currentContent.currentSpeed,
     speedList: currentContent.speedList,
+    speedShortcuts: {},
     newTabSpeed: {
       selectedOption:
         currentContent.newtab === "custom"

--- a/src/content-script/hooks/useKeyboardShortcuts.ts
+++ b/src/content-script/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,7 @@
 import { useEventListener } from "usehooks-ts";
 import { getBezelText } from "../utils";
+import { formatShortcut } from "@/utils/keyboardShortcut";
+import { useStorage } from "@/hooks/useStorage";
 import useSetSpeed from "./useSetSpeed";
 
 const ElementsToIgnore = [
@@ -13,7 +15,11 @@ const ElementsToIgnore = [
 ];
 
 function useKeyboardShortcuts() {
-  const { decreaseSpeed, increaseSpeed } = useSetSpeed();
+  const { decreaseSpeed, increaseSpeed, setSpeed } = useSetSpeed();
+  const [speedShortcuts] = useStorage(
+    "speedShortcuts",
+    {} as Record<string, string>,
+  );
 
   const triggerShortcutUi = (newSpeed: number) => {
     const bezelText = getBezelText();
@@ -27,6 +33,17 @@ function useKeyboardShortcuts() {
 
     const isInput = event.target.closest(ElementsToIgnore.join(",")) !== null;
     if (isInput) return;
+
+    const combo = formatShortcut(event);
+    const matched = Object.entries(speedShortcuts).find(
+      ([, sc]) => sc === combo,
+    );
+    if (matched) {
+      const speed = parseFloat(matched[0]);
+      setSpeed(speed);
+      triggerShortcutUi(speed);
+      return;
+    }
 
     if (event.shiftKey && ["Comma", "Period"].includes(event.code)) {
       const speedFunction =

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -9,6 +9,8 @@ export interface StorageContent {
   storageSchemaVersion: 2;
   lastSpeed: number;
   speedList: number[];
+  /** Map of speed value to shortcut string */
+  speedShortcuts: Record<string, string>;
   newTabSpeed: SingleChoiceSettingStorage<
     "normal" | "last" | "doNothing",
     number

--- a/src/utils/keyboardShortcut.ts
+++ b/src/utils/keyboardShortcut.ts
@@ -1,0 +1,14 @@
+export function formatShortcut(
+  e: Pick<
+    KeyboardEvent,
+    "code" | "ctrlKey" | "altKey" | "shiftKey" | "metaKey"
+  >,
+): string {
+  const parts: string[] = [];
+  if (e.ctrlKey) parts.push("Ctrl");
+  if (e.altKey) parts.push("Alt");
+  if (e.metaKey) parts.push("Meta");
+  if (e.shiftKey) parts.push("Shift");
+  parts.push(e.code);
+  return parts.join("+");
+}

--- a/static/tutorial/welcome-prep.js
+++ b/static/tutorial/welcome-prep.js
@@ -7,16 +7,5 @@ function optionsClick(e) {
     });
 }
 
-function shortcutOptionsClick(e) {
-    chrome.tabs.create({
-        url: 'chrome://extensions/shortcuts'
-    });
-}
-
-function settingsClick(e) {
-    chrome.tabs.create({
-        url: 'chrome://extensions/?id=' + chrome.runtime.id
-    });
-}
+// Removed unused handlers for Chrome shortcut and settings pages
 document.querySelector('#ext-options').addEventListener('click', optionsClick);
-// document.querySelector('#chrome-settings').addEventListener('click', settingsClick);

--- a/static/welcome.html
+++ b/static/welcome.html
@@ -52,7 +52,8 @@
         4. Use the keyboard shortcuts <span class="key">Shift</span> +
         <span class="key">,</span> and <span class="key">Shift</span> +
         <span class="key">.</span>
-        to quickly change the speed.
+        to quickly change the speed. You can also assign your own shortcut to
+        each speed from the options page.
       </p>
       <p>
         Go to


### PR DESCRIPTION
## Summary
- remove obsolete shortcut and settings handlers from `welcome-prep.js`

## Testing
- `npm run lint` *(fails: npm-run-all: not found)*