### PR TITLE
Fix lint errors from unused functions

### DIFF
--- a/static/tutorial/welcome-prep.js
+++ b/static/tutorial/welcome-prep.js
@@ -9,22 +9,7 @@ function optionsClick() {
   });
 }
 
-function shortcutOptionsClick() {
-  chrome.tabs.create({
-    url: "chrome://extensions/shortcuts",
-  });
-}
-
-function settingsClick() {
-  chrome.tabs.create({
-    url: "chrome://extensions/?id=" + chrome.runtime.id,
-  });
-}
-
 document
   .querySelector("#ext-options")
   .addEventListener("click", optionsClick);
-// document
-//   .querySelector('#chrome-settings')
-//   .addEventListener('click', settingsClick);
 


### PR DESCRIPTION
## Summary
- remove unused functions from welcome-prep.js

## Testing
- `npm run lint` *(fails: npm-run-all not found)*